### PR TITLE
Final Updates

### DIFF
--- a/python/app/g2panel
+++ b/python/app/g2panel
@@ -21,10 +21,12 @@ class MainWindow(QtWidgets.QMainWindow):
         pg.setConfigOption('background', (247, 247, 247))
         pg.setConfigOption('foreground', 'k')
         
+        
         #Load UI file as main Window
         super(MainWindow, self).__init__()
+        self.det = Detector()
         uic.loadUi('g2panel.ui', self)
-
+        self.chipInitialize()
         
         pen = pg.mkPen(color = (36, 119, 173), width=1) 
         #Plotting the data
@@ -34,7 +36,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.p1 = self.gamBitPlotWidget.plot(pen=pen)
 
         self.addPlot()
-        self.det = Detector()
         self.rcv = rs.Receiver(args[0].receiver_endpoint)
         self.rcv.udp_source = f"{self.det.udp_dstip}:{self.det.udp_dstport}"
         
@@ -45,7 +46,11 @@ class MainWindow(QtWidgets.QMainWindow):
 
         #Getting data from detectors
         self.update_fields()
-    
+        #Initializing from the detector to disable frames or trigger according to timing modes
+        if self.det.timing == timingMode.AUTO_TIMING:
+            self.triggerSpinBox.setDisabled(True)
+        if self.det.timing == timingMode.TRIGGER_EXPOSURE:
+            self.frameSpinBox.setDisabled(True)
         #For simple attributes it is possible to connect directly using a lambda 
         # do avoid having to make an extra function
         self.highVoltageSpinBox.editingFinished.connect(self.setHighVolatge)
@@ -140,6 +145,17 @@ class MainWindow(QtWidgets.QMainWindow):
         #help
         self.actionAbout.triggered.connect(self.show_about)
 
+    def chipInitialize(self):
+        if self.det.powerchip == True:
+            pass
+        else:
+            msg = QtWidgets.QMessageBox()
+            msg.setWindowTitle("Chip Powered Off!!!")
+            msg.setText("The chip is powered off. Please power on the Chip and run the program.\n Thank You")
+            msg.setIcon(QtWidgets.QMessageBox.Critical)
+            x = msg.exec_()
+            exit()
+            
     #to add plot and update it according to the values from GUI
     def addPlot(self):
         #Getting the intial axis value set from ui
@@ -353,11 +369,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
     #Setting initial trigger
     def setTrigger(self):
-        
         #If trigger mode is selected then the frame number is replaced by the triggers other wise it takes the frame number
         if self.det.timing==timingMode.TRIGGER_EXPOSURE:
             self.rcv.frames = self.triggerSpinBox.value()
-            #self.det.frames = self.triggerSpinBox.value()
             self.det.triggers = self.triggerSpinBox.value()
         #number of frames needs to go to both receiver and detector
         else:
@@ -425,13 +439,16 @@ class MainWindow(QtWidgets.QMainWindow):
         if selected:
             self.det.timing = timingMode.AUTO_TIMING
             self.rcv.frames = self.det.frames
-    
+            self.frameSpinBox.setDisabled(False)
+            self.triggerSpinBox.setDisabled(True)
+
     def triggerMode(self, selected):
         if selected:
             self.det.timing = timingMode.TRIGGER_EXPOSURE
             self.rcv.frames = self.det.triggers
+            self.frameSpinBox.setDisabled(True)
+            self.triggerSpinBox.setDisabled(False)
         
-
     #Safely powering off the detectors
     def powerOffDetector(self):
         #Asking user if they really want to power off the detectors
@@ -449,6 +466,7 @@ class MainWindow(QtWidgets.QMainWindow):
             time.sleep(1)
             #Power off chip
             self.det.powerchip = False
+            self.close()
 
     #Setting the referesh rate from the receiver
     def setStreamNth(self):
@@ -468,7 +486,6 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     app = QtWidgets.QApplication(sys.argv)
-
 
     main = MainWindow(args)
     main.show()

--- a/python/app/g2panel
+++ b/python/app/g2panel
@@ -21,12 +21,11 @@ class MainWindow(QtWidgets.QMainWindow):
         pg.setConfigOption('background', (247, 247, 247))
         pg.setConfigOption('foreground', 'k')
         
-        
         #Load UI file as main Window
         super(MainWindow, self).__init__()
         self.det = Detector()
         uic.loadUi('g2panel.ui', self)
-        self.chipInitialize()
+        self.check_powerchip()
         
         pen = pg.mkPen(color = (36, 119, 173), width=1) 
         #Plotting the data
@@ -51,6 +50,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.triggerSpinBox.setDisabled(True)
         if self.det.timing == timingMode.TRIGGER_EXPOSURE:
             self.frameSpinBox.setDisabled(True)
+
         #For simple attributes it is possible to connect directly using a lambda 
         # do avoid having to make an extra function
         self.highVoltageSpinBox.editingFinished.connect(self.setHighVolatge)
@@ -99,7 +99,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.stopButton.clicked.connect(self.stopProcess)
 
         #Plot related settings
-
         #using a validator to make sure we have an integer, then set the streaming
         #frequency of the preview
         validator = QtGui.QIntValidator() 
@@ -124,7 +123,6 @@ class MainWindow(QtWidgets.QMainWindow):
         #Power off button
         self.closeButton.clicked.connect(self.powerOffDetector)
 
-
         #Pedestal correction 
         self.pedestalCheckBox.stateChanged.connect(lambda x: setattr(self.zmq_rcv, 'collect_pedestal', x))
         
@@ -145,7 +143,7 @@ class MainWindow(QtWidgets.QMainWindow):
         #help
         self.actionAbout.triggered.connect(self.show_about)
 
-    def chipInitialize(self):
+    def check_powerchip(self):
         if self.det.powerchip == True:
             pass
         else:
@@ -175,7 +173,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.gamBitPlotWidget.setLabel('bottom',"<span style=\"color:black;font-size:14px\">Channel [#]</span>")
         self.gamBitPlotWidget.setXRange(Xmin, Xmax, padding=0.01)
         self.gamBitPlotWidget.setYRange(0, 2, padding=0.05)
-
 
     def show_about(self):
         msg = QtWidgets.QMessageBox()
@@ -234,7 +231,6 @@ class MainWindow(QtWidgets.QMainWindow):
             exposuretime0 = (tExp / 1e-3)
             self.exposureSpinBox.setValue(exposuretime0)
 
-
         #Converting to right time unit for period
         tPeriod = self.det.period
         if tPeriod < 100e-9:
@@ -291,9 +287,6 @@ class MainWindow(QtWidgets.QMainWindow):
             case timingMode.TRIGGER_EXPOSURE:
                 self.triggerRadioButton.setChecked(True)
 
-
-        #TODO! Add the additional fields
-
     #Updating progress bar
     def update_progress(self):
 
@@ -321,9 +314,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.stopButton.hide()
             #Showing start button to start new acquistion after completing one acquistion
             self.startButton.show()
-
         self.last_progress = progress_d
-
 
     #Updating the status of the detector
     def update_status(self):
@@ -385,7 +376,6 @@ class MainWindow(QtWidgets.QMainWindow):
     #updating index values
     def setIndex(self):
         self.rcv.findex = self.indexSpinBox.value()
-
 
     #Function for setting exposure time and time unit
     def setExptime(self):
@@ -483,7 +473,6 @@ if __name__ == '__main__':
         nargs = '?',
         type=str,
     )
-
     args = parser.parse_args()
     app = QtWidgets.QApplication(sys.argv)
 

--- a/python/app/g2panel.ui
+++ b/python/app/g2panel.ui
@@ -1022,7 +1022,7 @@ border-color: rgb(0, 0, 0);
 color: rgb(255, 255, 0);</string>
     </property>
     <property name="text">
-     <string>Safely Power Off Detector</string>
+     <string>Safely Power Off Detector and Exit</string>
     </property>
    </widget>
    <widget class="QLabel" name="statusLabel">


### PR DESCRIPTION
Updates 
- When selecting trigger mode frames become grayed out, vice versa when in auto mode triggers are grayed out
- if the chip is powered off when starting the GUI, display a warning message and then exit
- Rename the safely power off to safely power of and exit, and exit the GUI after the message 